### PR TITLE
一覧を取得するREAD処理の実装

### DIFF
--- a/sql/001-create-table-and-load-data.sql
+++ b/sql/001-create-table-and-load-data.sql
@@ -9,6 +9,6 @@ CREATE TABLE pokemons (
 );
 
 INSERT INTO pokemons (pokedexNo, name, nickname) VALUES (1, "フシギダネ", "ふしぎ");
-INSERT INTO pokemons (pokedexNo, name) VALUES (4, "ヒトカゲ", "ドン");
+INSERT INTO pokemons (pokedexNo, name, nickname) VALUES (4, "ヒトカゲ", "ドン");
 INSERT INTO pokemons (pokedexNo, name, nickname) VALUES (7, "ゼニガメ", "かめ");
 INSERT INTO pokemons (pokedexNo,name) VALUES (16, "ポッポ");

--- a/src/main/java/com/koki/task9/controller/PokemonController.java
+++ b/src/main/java/com/koki/task9/controller/PokemonController.java
@@ -1,0 +1,26 @@
+package com.koki.task9.controller;
+
+import com.koki.task9.response.PokemonResponse;
+import com.koki.task9.service.PokemonService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+
+public class PokemonController {
+
+    private final PokemonService pokemonService;
+
+    public PokemonController(PokemonService pokemonService) {
+        this.pokemonService = pokemonService;
+    }
+
+    @GetMapping("/pokemons")
+    public List<PokemonResponse> getPokemons() {
+        return pokemonService.findAll().stream().map(PokemonResponse::new).toList();
+    }
+
+
+}

--- a/src/main/java/com/koki/task9/entity/Pokemon.java
+++ b/src/main/java/com/koki/task9/entity/Pokemon.java
@@ -1,0 +1,21 @@
+package com.koki.task9.entity;
+
+import lombok.Getter;
+
+public class Pokemon {
+    @Getter
+    private int id;
+    @Getter
+    private int pokedexNo;
+    @Getter
+    private String name;
+    @Getter
+    private String nickname;
+
+    public Pokemon(int id, int pokedexNo, String name, String nickname) {
+        this.id = id;
+        this.pokedexNo = pokedexNo;
+        this.name = name;
+        this.nickname = nickname;
+    }
+}

--- a/src/main/java/com/koki/task9/entity/Pokemon.java
+++ b/src/main/java/com/koki/task9/entity/Pokemon.java
@@ -2,14 +2,15 @@ package com.koki.task9.entity;
 
 import lombok.Getter;
 
+@Getter
 public class Pokemon {
-    @Getter
+
     private int id;
-    @Getter
+
     private int pokedexNo;
-    @Getter
+
     private String name;
-    @Getter
+
     private String nickname;
 
     public Pokemon(int id, int pokedexNo, String name, String nickname) {

--- a/src/main/java/com/koki/task9/mapper/PokemonMapper.java
+++ b/src/main/java/com/koki/task9/mapper/PokemonMapper.java
@@ -1,0 +1,17 @@
+package com.koki.task9.mapper;
+
+import com.koki.task9.entity.Pokemon;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+
+import java.util.List;
+import java.util.Optional;
+
+@Mapper
+public interface PokemonMapper {
+    @Select("SELECT * FROM pokemons")
+    List<Pokemon> findAll();
+
+    @Select("SELECT * FROM pokemons WHERE id = #{id}")
+    Optional<Pokemon> findById(int id);
+}

--- a/src/main/java/com/koki/task9/response/PokemonResponse.java
+++ b/src/main/java/com/koki/task9/response/PokemonResponse.java
@@ -1,0 +1,20 @@
+package com.koki.task9.response;
+
+import com.koki.task9.entity.Pokemon;
+import lombok.Getter;
+
+public class PokemonResponse {
+    @Getter
+    private int pokedexNo;
+    @Getter
+    private String name;
+    @Getter
+    private String nickname;
+
+    public PokemonResponse(Pokemon pokemon) {
+        this.pokedexNo = pokemon.getPokedexNo();
+        this.name = pokemon.getName();
+        this.nickname = pokemon.getNickname();
+    }
+
+}

--- a/src/main/java/com/koki/task9/response/PokemonResponse.java
+++ b/src/main/java/com/koki/task9/response/PokemonResponse.java
@@ -3,15 +3,19 @@ package com.koki.task9.response;
 import com.koki.task9.entity.Pokemon;
 import lombok.Getter;
 
+@Getter
 public class PokemonResponse {
-    @Getter
+
+    private int id;
+
     private int pokedexNo;
-    @Getter
+
     private String name;
-    @Getter
+
     private String nickname;
 
     public PokemonResponse(Pokemon pokemon) {
+        this.id = pokemon.getId();
         this.pokedexNo = pokemon.getPokedexNo();
         this.name = pokemon.getName();
         this.nickname = pokemon.getNickname();

--- a/src/main/java/com/koki/task9/service/PokemonService.java
+++ b/src/main/java/com/koki/task9/service/PokemonService.java
@@ -7,6 +7,4 @@ import java.util.List;
 
 public interface PokemonService {
     List<Pokemon> findAll();
-
-
 }

--- a/src/main/java/com/koki/task9/service/PokemonService.java
+++ b/src/main/java/com/koki/task9/service/PokemonService.java
@@ -1,0 +1,12 @@
+package com.koki.task9.service;
+
+
+import com.koki.task9.entity.Pokemon;
+
+import java.util.List;
+
+public interface PokemonService {
+    List<Pokemon> findAll();
+
+
+}

--- a/src/main/java/com/koki/task9/service/PokemonServiceImpl.java
+++ b/src/main/java/com/koki/task9/service/PokemonServiceImpl.java
@@ -1,0 +1,23 @@
+package com.koki.task9.service;
+
+import com.koki.task9.entity.Pokemon;
+import com.koki.task9.mapper.PokemonMapper;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class PokemonServiceImpl implements PokemonService {
+    private final PokemonMapper pokemonMapper;
+
+    public PokemonServiceImpl(PokemonMapper pokemonMapper) {
+        this.pokemonMapper = pokemonMapper;
+    }
+
+    @Override
+    public List<Pokemon> findAll() {
+        return pokemonMapper.findAll();
+    }
+
+
+}


### PR DESCRIPTION
### 今回したこと：ポケモンの一覧を取得するREAD処理の実装

### 次にしたいこと：指定したidのポケモンの情報を取得する処理の実装、指定したidがない場合のエラー処理の実装

https://github.com/kokiyoda/Task9/pull/1/commits/2bef7e93cd641a48c63df4feea48dbd5af0a47a7

テーブル名：pokemons

|id|pokedex|name|nickname|
|---|---:|---|---|
|1|1|フシギダネ|ふしぎ|
|2|4|ヒトカゲ|ドン|
|3|7|ゼニガメ|かめ|
|4|16|ポッポ|null|

レスポンス情報はid以外を返すようにレスポンスクラスを作成
Postmanでの実行結果でステータスコードが200であること、id以外の情報が取得ができていることを確認できました
![スクリーンショット 2023-07-10 082000](https://github.com/kokiyoda/Task9/assets/134734832/0cf5d36a-378c-4925-9566-98af2856a78d)


